### PR TITLE
0.0.4 — canonical BM25L variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,36 @@ ranked_indices = np.argsort(similarity.flatten())[::-1]
 print("Ranked documents:", ranked_indices)
 ```
 
+#### Direct Retrieval Scores
+
+Use `score()` when you want direct query-document BM25 scores rather than cosine
+similarity over sparse feature vectors:
+
+```python
+from bm25_vectorizer import BM25Vectorizer
+import numpy as np
+
+corpus = [
+    "the quick brown fox",
+    "the lazy dog",
+    "document retrieval system",
+]
+
+vectorizer = BM25Vectorizer(transformer="bm25plus").fit(corpus)
+scores = vectorizer.score(["quick fox"])
+ranked_indices = vectorizer.rank(["quick fox"])[0]
+print("Ranked documents:", ranked_indices)
+```
+
+`transform()` intentionally returns a sparse document-term feature matrix for
+scikit-learn interoperability. `score()` performs query-document scoring
+directly. For BM25+, this includes the canonical `delta * idf` contribution for
+query terms that are absent from a document, which cannot be represented exactly
+in a sparse feature matrix without materializing dense absent-term weights.
+`rank()` is a convenience wrapper around `score()` that returns descending
+document indices, optionally with sorted scores. It ranks queries in batches;
+lower `batch_size` to reduce peak memory on large query sets.
+
 #### Classes
 
 * BM25TransformerBase: Abstract base class for BM25 transformers.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 ## BM25 vectorizer
 
 BM25 Transformers and Vectorizer
-This Python package provides implementations of BM25, BM25L, BM25+, BM25-adpt, BM25T, and TF₁ₐₚ × IDF ranking functions
-as scikit-learn compatible transformers and a vectorizer. These are used for information retrieval and text processing,
-extending the traditional TF-IDF approach with document length normalization and term frequency saturation.
+This Python package provides implementations of BM25, BM25L (two variants), BM25+, BM25-adpt, BM25T, and TF₁ₐₚ × IDF
+ranking functions as scikit-learn compatible transformers and a vectorizer. These are used for information retrieval
+and text processing, extending the traditional TF-IDF approach with document length normalization and term frequency
+saturation.
 
 ### Installation
 
@@ -19,7 +20,7 @@ Similar to tf-idf from sklearn,
 BM25Vectorizer(transformer="bm25plus").fit(corpus)
 ```
 
-where `transformer` can be one of the following: `bm25l`, `bm25plus`, `bm25adpt`, `bm25t`, `tfidf1ap`
+where `transformer` can be one of the following: `bm25`, `bm25l`, `bm25l_canonical`, `bm25plus`, `bm25adpt`, `bm25t`, `tfidf1ap`
 
 #### Feature Extraction
 
@@ -111,7 +112,12 @@ lower `batch_size` to reduce peak memory on large query sets.
 
 * BM25TransformerBase: Abstract base class for BM25 transformers.
 * BM25Transformer: Implements the standard BM25 scoring function.
-* BM25LTransformer: Implements BM25L, which adjusts for document length more aggressively.
+* BM25LTransformer: Implements BM25L in the `rank_bm25`-compatible form (carries an extra
+  `tf_td` multiplier outside the normalised-tf factor; deviates from the original Lv & Zhai 2011 paper).
+* BM25LCanonicalTransformer: Implements canonical BM25L from Lv & Zhai (2011), as reviewed by
+  Kamphuis et al. (ECIR 2020) and used by the `bm25s` library. No extra `tf_td` factor;
+  retrieval scoring (`score()` / `rank()`) includes the constant absent-term baseline
+  `idf · (k₁+1)·δ / (k₁+δ)` for query terms not present in a document.
 * BM25PlusTransformer: Implements BM25+, which adds a constant boost to scores.
 * BM25AdptTransformer: Implements BM25-adpt, using term-specific $k_1^t$ via information gain.
 * BM25TTransformer: Implements BM25T, using term-specific $k_1^t$ via log-logistic estimation.
@@ -137,10 +143,13 @@ Below are the formulas for the BM25 variants implemented in this package, provid
 * Standard BM25 IDF: $\text{idf}(t) = \log\left(\frac{N - n(t) + 0.5}{n(t) + 0.5}\right)$
 * Standard BM25
   Score: $\text{BM25}(t,d) = \text{IDF}(t) \cdot \frac{f(t,d) \cdot (k_1 + 1)}{f(t,d) + k_1 \cdot (1 - b + b \cdot \frac{|d|}{\text{avgdl}})}$
-* BM25L IDF: $\text{idf}(t) = \log\left(\frac{N + 1}{n(t) + 0.5}\right)$
-* BM25L
+* BM25L IDF (both variants): $\text{idf}(t) = \log\left(\frac{N + 1}{n(t) + 0.5}\right)$
+* BM25L (`bm25l`, rank_bm25-compatible)
   Score: $\text{BM25L}(t,d) = \text{IDF}(t) \cdot \frac{f(t,d) \cdot (k_1 + 1) \cdot (c(t,d) + \delta)}{k_1 + c(t,d) + \delta}$
   where $c(t,d) = \frac{f(t,d)}{1 - b + b \cdot \frac{|d|}{\text{avgdl}}}$
+* BM25L canonical (`bm25l_canonical`, Lv & Zhai 2011 / Kamphuis 2020 / `bm25s`)
+  Score: $\text{BM25L}(t,d) = \text{IDF}(t) \cdot \frac{(k_1 + 1) \cdot (c(t,d) + \delta)}{k_1 + c(t,d) + \delta}$ when $f(t,d) > 0$;
+  $\text{IDF}(t) \cdot \frac{(k_1 + 1) \cdot \delta}{k_1 + \delta}$ when $f(t,d) = 0$ (absent-term baseline, included by `score()` / `rank()`).
 
 * BM25+ IDF: $\text{idf}(t) = \log\left(\frac{N + 1}{n(t)}\right)$
 
@@ -184,7 +193,11 @@ Recent checks were run to verify practical retrieval behavior and formula consis
 - **Real retrieval test (Hugging Face `ag_news`, 1000 documents):**
   BM25-based retrieval produced `top-1 = 0.772` and `top-5 hit = 0.953` (random top-1 baseline: `0.278`).
 - **Reference agreement (`rank_bm25`)**:
-  For `bm25`, `bm25l`, `bm25plus`, rank correlation was `Spearman = 1.0` and `Kendall = 1.0` on shared corpora/queries.
+  For `bm25`, `bm25l`, `bm25plus`, scores match `rank_bm25` exactly on shared corpora/queries
+  (`np.allclose` over all queries; rank correlation = 1.0).
+- **Reference agreement (`bm25s`)**:
+  For `bm25l_canonical`, `score()` matches `bm25s` (`method="bm25l"`) exactly on shared
+  corpora/queries, including the absent-term baseline contribution.
 - **Oracle and invariants checks**:
   Expected ranking behavior (coverage, rare-term preference, length normalization) and core invariants (TF saturation, IDF ordering, `b=0` vs `b=1`) were confirmed.
 
@@ -196,7 +209,10 @@ For retrieval, compare documents by ranking/similarity (e.g., cosine over transf
 ## References
 
 - https://github.com/dorianbrown/rank_bm25
-
+- https://github.com/xhluca/bm25s
 - http://www.cs.otago.ac.nz/homepages/andrew/papers/2014-2.pdf
   "Improvements to BM25 and Language Models Examined", Trotman et al.
+- Lv & Zhai (CIKM 2011), "When Documents Are Very Long, BM25 Fails!" (BM25L).
+- Kamphuis, de Vries, Boytsov, Lin (ECIR 2020), "Which BM25 Do You Mean? A Large-Scale
+  Reproducibility Study of Scalable Retrieval Libraries".
 - https://nlp.stanford.edu/IR-book/html/htmledition/okapi-bm25-a-non-binary-model-1.html

--- a/bm25_vectorizer/__init__.py
+++ b/bm25_vectorizer/__init__.py
@@ -6,7 +6,7 @@ from numpy import ndarray
 from scipy.sparse import csr_matrix
 from scipy.sparse.linalg import norm as sparse_norm
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
 from sklearn.utils.validation import check_is_fitted
 from typing_extensions import Self, override
 
@@ -91,12 +91,12 @@ class BM25TransformerBase(TransformerMixin, BaseEstimator):
         Calculates IDF and average document length.
         """  # noqa
         df: ndarray = np.bincount(X.indices, minlength=X.shape[1])
-        n_samples: int = X.shape[0]
+        return self.fit_from_stats(df, X.shape[0], X.sum(axis=1).A1)
+
+    def fit_from_stats(self, df: ndarray, n_samples: int, doc_len: ndarray) -> Self:
         idf: ndarray = self._calc_idf(df, n_samples)
         self._idf_diag = sp.diags(idf, offsets=0, format="csr")
-        # old (seems like not correct):
-        # self.avgdl = np.mean(np.diff(X.indptr))
-        self.doc_len_ = X.sum(axis=1).A1  # Σ tf_ij for every document
+        self.doc_len_ = doc_len
         self.avgdl = self.doc_len_.mean()
         return self
 
@@ -127,7 +127,7 @@ class BM25Transformer(BM25TransformerBase):
             idf: ndarray = np.log1p((n_samples - df + 0.5) / (df + 0.5))
         else:
             idf: ndarray = np.log((n_samples - df + 0.5) / (df + 0.5))
-        return np.maximum(idf, self.epsilon * float(np.mean(idf)))
+        return np.where(idf < 0, self.epsilon * float(np.mean(idf)), idf)
 
     @override
     def transform(self, X: csr_matrix, copy: bool = True) -> csr_matrix:
@@ -148,8 +148,6 @@ class BM25Transformer(BM25TransformerBase):
         """  # noqa
         if copy:
             X = X.copy()
-        # old (seems like not correct):
-        # dl: ndarray = np.diff(X.indptr)
         dl = X.sum(axis=1).A1  # token length of each row in X
         rep: ndarray = np.repeat(dl, np.diff(X.indptr))
         data: ndarray = X.data * (self.k1 + 1) / (X.data + self.k1 * (1 - self.b + self.b * rep / self.avgdl))
@@ -180,9 +178,9 @@ class BM25LTransformer(BM25TransformerBase):
     def transform(self, X: csr_matrix, copy: bool = True) -> csr_matrix:
         """
         BM25L score for term t in document d:
-                                  (k1 + 1) · (c_td + δ)
-        BM25L(t, d) = idf(t) · ------------------------------
-                                     k1 + c_td + δ
+                                  tf_td · (k1 + 1) · (c_td + δ)
+        BM25L(t, d) = idf(t) · -------------------------------------
+                                           k1 + c_td + δ
         with
           c_td = tf_td / (1 – b + b · |d| / avgdl)
         where
@@ -202,8 +200,7 @@ class BM25LTransformer(BM25TransformerBase):
         rep: ndarray = np.repeat(dl, nnz_per_doc)
         # Calculate c_td
         ctd: ndarray = X.data / (1 - self.b + self.b * rep / self.avgdl)
-        # Apply BM25L formula - without multiplying by X.data again
-        data: ndarray = (self.k1 + 1) * (ctd + self.delta) / (self.k1 + ctd + self.delta)
+        data: ndarray = X.data * (self.k1 + 1) * (ctd + self.delta) / (self.k1 + ctd + self.delta)
         X = sp.csr_matrix((data, X.indices, X.indptr), shape=X.shape)
         if self.use_idf:
             X = X @ self._idf_diag
@@ -343,8 +340,16 @@ class BM25AdptTransformer(BM25TransformerBase):
         Compute information gain values G_r^q for different r values.
         Return G_1^q and a list of all G_r^q/G_1^q values for optimization.
         """  # noqa
-        # Compute df_r values for r=0 to max_r+1
-        df_values = [self._compute_df_r(X, r, df) for r in range(max_r + 2)]
+        dl = X.sum(axis=1).A1
+        avgdl = np.mean(dl)
+        nnz_per_doc = np.diff(X.indptr)
+        rep_dl = np.repeat(dl, nnz_per_doc)
+        ctd = X.data / (1 - self.b + self.b * rep_dl / avgdl)
+
+        df_values = [np.full(X.shape[1], X.shape[0]), df]
+        for r in range(2, max_r + 2):
+            mask = ctd >= r - 0.5
+            df_values.append(np.bincount(X.indices[mask], minlength=X.shape[1]))
 
         # Calculate G_r^q values
         g_values = []
@@ -419,6 +424,10 @@ class BM25AdptTransformer(BM25TransformerBase):
         # Optimize for term-specific k1 values
         self.k1_terms = self._optimize_k1(g_normalized)
         return self
+
+    @override
+    def fit_from_stats(self, df: ndarray, n_samples: int, doc_len: ndarray) -> Self:
+        raise NotImplementedError("BM25-adpt requires fitting on the full term-count matrix")
 
     @override
     def transform(self, X: csr_matrix, copy: bool = True) -> csr_matrix:
@@ -511,7 +520,7 @@ class BM25TTransformer(BM25TransformerBase):
             # Derivative of (k1/(k1-1))*log(k1)
             return np.log(k1) / (k1 - 1) - k1 * np.log(k1) / ((k1 - 1) ** 2) + 1 / (k1 - 1)
 
-    def _compute_term_specific_k1(self, X: csr_matrix, elite_sets: list[list[int]], df: ndarray) -> ndarray:
+    def _compute_term_specific_k1(self, X: csr_matrix, df: ndarray) -> ndarray:
         """
         Compute term-specific k1 values using the log-logistic method described in the paper.
         Use Newton-Raphson method to solve for k1'.
@@ -519,34 +528,21 @@ class BM25TTransformer(BM25TransformerBase):
         n_terms = X.shape[1]
         k1_terms = np.full(n_terms, self.k1)  # Initialize with default k1
 
-        # Compute document lengths
         dl = X.sum(axis=1).A1
+        norm = 1 - self.b + self.b * dl / self.avgdl
+        X_csc = X.tocsc()
 
         # For each term, solve for term-specific k1
         for term_idx in range(n_terms):
             if df[term_idx] == 0:  # Skip terms that don't appear in corpus
                 continue
 
-            # Get the elite set (documents containing this term)
-            elite_set = elite_sets[term_idx]
-            if not elite_set:  # Skip if elite set is empty
+            start, end = X_csc.indptr[term_idx], X_csc.indptr[term_idx + 1]
+            if start == end:
                 continue
 
-            # Compute log(c_td)+1 for all documents in elite set
-            log_ctd_sum = 0.0
-            for doc_idx in elite_set:
-                # Find term frequency in this document
-                start, end = X.indptr[doc_idx], X.indptr[doc_idx + 1]
-                term_pos = np.where(X.indices[start:end] == term_idx)[0]
-
-                if len(term_pos) > 0:  # Term found in document
-                    tf = X.data[start + term_pos[0]]
-                    # Compute c_td (normalized term frequency)
-                    c_td = tf / (1 - self.b + self.b * dl[doc_idx] / self.avgdl)
-                    log_ctd_sum += np.log(c_td + 1)
-
-            # Target value for optimization
-            target = log_ctd_sum / df[term_idx]
+            c_td = X_csc.data[start:end] / norm[X_csc.indices[start:end]]
+            target = np.log(c_td + 1).sum() / df[term_idx]
 
             # Newton-Raphson method to solve for k1'
             k1_current = self.k1  # Start with default k1
@@ -583,17 +579,13 @@ class BM25TTransformer(BM25TransformerBase):
         self._idf_diag = sp.diags(idf, offsets=0, format="csr")
         self.avgdl = X.sum(axis=1).A1.mean()
 
-        # Build elite sets (documents containing each term)
-        elite_sets = [[] for _ in range(X.shape[1])]
-        for doc_idx in range(X.shape[0]):
-            start, end = X.indptr[doc_idx], X.indptr[doc_idx + 1]
-            for j in range(start, end):
-                term_idx = X.indices[j]
-                elite_sets[term_idx].append(doc_idx)
-
         # Compute term-specific k1 values
-        self.k1_terms = self._compute_term_specific_k1(X, elite_sets, df)
+        self.k1_terms = self._compute_term_specific_k1(X, df)
         return self
+
+    @override
+    def fit_from_stats(self, df: ndarray, n_samples: int, doc_len: ndarray) -> Self:
+        raise NotImplementedError("BM25T requires fitting on the full term-count matrix")
 
     @override
     def transform(self, X: csr_matrix, copy: bool = True) -> csr_matrix:
@@ -743,6 +735,7 @@ class BM25Vectorizer(TfidfVectorizer, SimilarityMixin):
         delta: float = 1.0,
         epsilon: float = 0.25,
         log1p_idf: bool = False,
+        use_idf: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -752,18 +745,193 @@ class BM25Vectorizer(TfidfVectorizer, SimilarityMixin):
         self.delta: float = delta
         self.epsilon: float = epsilon
         self.log1p_idf: bool = log1p_idf
+        self.use_idf: bool = use_idf
         self._tfidf: BM25TransformerBase | None = None
+        self._df: ndarray | None = None
+        self._n_samples: int | None = None
+        self._doc_len: ndarray | None = None
+        self._count_matrix: csr_matrix | None = None
 
     def fit(self, raw_documents: list | np.ndarray, y: np.ndarray | None = None) -> Self:
-        X: csr_matrix = super().fit_transform(raw_documents)
-        self._tfidf = self.transformer_dispatch[self.transformer](
-            k1=self.k1, b=self.b, delta=self.delta, epsilon=self.epsilon, log1p_idf=self.log1p_idf
-        ).fit(X)
+        X: csr_matrix = CountVectorizer.fit_transform(self, raw_documents)
+        self._fit_count_matrix(X)
         return self
+
+    def _fit_count_matrix(self, X: csr_matrix) -> None:
+        self._df = np.bincount(X.indices, minlength=X.shape[1])
+        self._n_samples = X.shape[0]
+        self._doc_len = X.sum(axis=1).A1
+        self._count_matrix = X
+        self._tfidf = self.transformer_dispatch[self.transformer](
+            k1=self.k1,
+            b=self.b,
+            delta=self.delta,
+            epsilon=self.epsilon,
+            log1p_idf=self.log1p_idf,
+            use_idf=self.use_idf,
+        ).fit(X)
 
     def transform(self, raw_documents: list | np.ndarray) -> csr_matrix:
         check_is_fitted(self, "_tfidf")
-        return super().transform(raw_documents)
+        counts = CountVectorizer.transform(self, raw_documents)
+        return self._tfidf.transform(counts)
+
+    def fit_transform(self, raw_documents: list | np.ndarray, y: np.ndarray | None = None) -> csr_matrix:
+        X: csr_matrix = CountVectorizer.fit_transform(self, raw_documents)
+        self._fit_count_matrix(X)
+        return self._tfidf.transform(X)
+
+    def _get_weighting_transformer(self, transformer: str | None = None) -> BM25TransformerBase:
+        if transformer is None or transformer == self.transformer:
+            return self._tfidf
+
+        if self._df is None or self._n_samples is None or self._doc_len is None:
+            raise RuntimeError("fit() must be called before using an alternative transformer")
+
+        if transformer in {"bm25adpt", "bm25t"}:
+            if self._count_matrix is None:
+                raise RuntimeError(f"Alternative transformer '{transformer}' requires fitted corpus counts")
+            return self.transformer_dispatch[transformer](
+                k1=self.k1,
+                b=self.b,
+                delta=self.delta,
+                epsilon=self.epsilon,
+                log1p_idf=self.log1p_idf,
+                use_idf=self.use_idf,
+            ).fit(self._count_matrix)
+
+        return self.transformer_dispatch[transformer](
+            k1=self.k1,
+            b=self.b,
+            delta=self.delta,
+            epsilon=self.epsilon,
+            log1p_idf=self.log1p_idf,
+            use_idf=self.use_idf,
+        ).fit_from_stats(self._df, self._n_samples, self._doc_len)
+
+    def score(
+        self,
+        queries: str | Iterable[str] | sp.spmatrix,
+        documents: Iterable[str] | sp.spmatrix | None = None,
+        transformer: str | None = None,
+    ) -> ndarray:
+        """
+        Compute direct query-document retrieval scores.
+
+        Unlike cosine similarity over transformed sparse feature vectors, this
+        sums each query term's contribution against each document. For BM25+,
+        this includes the canonical delta contribution for query terms that are
+        absent from a document.
+        """
+        check_is_fitted(self, "_tfidf")
+
+        query_counts = self._count_documents(queries)
+        document_counts = self._get_document_counts(documents)
+
+        tf = self._get_weighting_transformer(transformer)
+        if isinstance(tf, BM25PlusTransformer):
+            return self._score_bm25plus(query_counts, document_counts, tf)
+
+        document_weights = tf.transform(document_counts)
+        return (query_counts @ document_weights.T).toarray()
+
+    def _count_documents(self, documents: str | Iterable[str] | sp.spmatrix) -> csr_matrix:
+        if sp.isspmatrix(documents):
+            return documents.tocsr(copy=False)
+        docs = [documents] if isinstance(documents, str) else list(documents)
+        return CountVectorizer.transform(self, docs)
+
+    def _get_document_counts(self, documents: Iterable[str] | sp.spmatrix | None = None) -> csr_matrix:
+        if documents is None:
+            if self._count_matrix is None:
+                raise RuntimeError("fit() must be called before scoring fitted documents")
+            return self._count_matrix
+        return self._count_documents(documents)
+
+    def _score_bm25plus(
+        self,
+        query_counts: csr_matrix,
+        document_counts: csr_matrix,
+        transformer: BM25PlusTransformer,
+    ) -> ndarray:
+        if query_counts.shape[1] != document_counts.shape[1]:
+            raise ValueError("query and document matrices must have the same number of features")
+
+        dl = document_counts.sum(axis=1).A1
+        nnz_per_doc = np.diff(document_counts.indptr)
+        rep = np.repeat(dl, nnz_per_doc)
+        data = (document_counts.data * (transformer.k1 + 1)) / (
+            transformer.k1 * (1 - transformer.b + transformer.b * rep / transformer.avgdl) + document_counts.data
+        )
+        component = sp.csr_matrix((data, document_counts.indices, document_counts.indptr), shape=document_counts.shape)
+
+        if transformer.use_idf:
+            idf = transformer._idf_diag.diagonal()
+            component = component @ transformer._idf_diag
+            baseline = query_counts @ (idf * transformer.delta)
+        else:
+            baseline = query_counts.sum(axis=1).A1 * transformer.delta
+
+        scores = (query_counts @ component.T).toarray()
+        return scores + np.asarray(baseline).reshape(-1, 1)
+
+    def rank(
+        self,
+        queries: str | Iterable[str] | sp.spmatrix,
+        documents: Iterable[str] | sp.spmatrix | None = None,
+        transformer: str | None = None,
+        top_n: int | None = None,
+        return_scores: bool = False,
+        batch_size: int = 4096,
+    ) -> ndarray | tuple[ndarray, ndarray]:
+        """
+        Rank documents for each query using direct retrieval scores.
+
+        Returns document indices sorted by descending score. If `return_scores`
+        is True, also returns the sorted scores with the same shape.
+        """
+        check_is_fitted(self, "_tfidf")
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+
+        query_counts = self._count_documents(queries)
+        document_counts = self._get_document_counts(documents)
+        n_queries = query_counts.shape[0]
+        n_documents = document_counts.shape[0]
+        if top_n is None:
+            top_n = n_documents
+        if not 0 < top_n <= n_documents:
+            raise ValueError("top_n must be between 1 and the number of documents")
+
+        tf = self._get_weighting_transformer(transformer)
+        document_weights = None if isinstance(tf, BM25PlusTransformer) else tf.transform(document_counts)
+        ranked_batches = []
+        score_batches = []
+
+        for start in range(0, n_queries, batch_size):
+            end = min(start + batch_size, n_queries)
+            query_batch = query_counts[start:end]
+            if isinstance(tf, BM25PlusTransformer):
+                score_batch = self._score_bm25plus(query_batch, document_counts, tf)
+            else:
+                score_batch = (query_batch @ document_weights.T).toarray()
+
+            if top_n == n_documents:
+                ranked_batch = np.argsort(score_batch, axis=1)[:, ::-1]
+            else:
+                candidate_idx = np.argpartition(score_batch, -top_n, axis=1)[:, -top_n:]
+                candidate_scores = np.take_along_axis(score_batch, candidate_idx, axis=1)
+                order = np.argsort(candidate_scores, axis=1)[:, ::-1]
+                ranked_batch = np.take_along_axis(candidate_idx, order, axis=1)
+
+            ranked_batches.append(ranked_batch)
+            if return_scores:
+                score_batches.append(np.take_along_axis(score_batch, ranked_batch, axis=1))
+
+        ranked = np.vstack(ranked_batches)
+        if not return_scores:
+            return ranked
+        return ranked, np.vstack(score_batches)
 
     def _vectorize(
         self,
@@ -802,13 +970,7 @@ class BM25Vectorizer(TfidfVectorizer, SimilarityMixin):
         else:
             raise TypeError("item must be a raw document (str), an iterable[str], or a scipy sparse row-vector")
 
-        counts = super().transform(docs)
+        counts = CountVectorizer.transform(self, docs)
 
-        # If no weighting requested → return raw counts
-        if transformer is None or transformer == self.transformer:
-            tf = self._tfidf
-        else:  # use the alternative transformer lazily
-            tf = self.transformer_dispatch[transformer](
-                k1=self.k1, b=self.b, delta=self.delta, epsilon=self.epsilon, log1p_idf=self.log1p_idf
-            ).fit(counts)
+        tf = self._get_weighting_transformer(transformer)
         return tf.transform(counts)

--- a/bm25_vectorizer/__init__.py
+++ b/bm25_vectorizer/__init__.py
@@ -18,7 +18,7 @@ compatible with scikit-learn's API.
 They can be used as alternatives to TF-IDF for text ranking and retrieval tasks.
 """  # noqa
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 
 class BM25TransformerBase(TransformerMixin, BaseEstimator):
@@ -158,6 +158,15 @@ class BM25Transformer(BM25TransformerBase):
 
 
 class BM25LTransformer(BM25TransformerBase):
+    """
+    BM25L variant compatible with `rank_bm25`.
+
+    Carries an extra ``tf_td`` multiplier outside the normalised-tf factor.
+    This matches `rank_bm25.BM25L` exactly but deviates from the canonical
+    Lv & Zhai (2011) / Kamphuis et al. (2020) formulation; for that, see
+    :class:`BM25LCanonicalTransformer`.
+    """  # noqa
+
     @override
     def _calc_idf(self, df: ndarray, n_samples: int) -> ndarray:
         """
@@ -177,21 +186,16 @@ class BM25LTransformer(BM25TransformerBase):
     @override
     def transform(self, X: csr_matrix, copy: bool = True) -> csr_matrix:
         """
-        BM25L score for term t in document d:
+        BM25L score (rank_bm25-compatible) for term t in document d:
                                   tf_td · (k1 + 1) · (c_td + δ)
         BM25L(t, d) = idf(t) · -------------------------------------
                                            k1 + c_td + δ
         with
           c_td = tf_td / (1 – b + b · |d| / avgdl)
-        where
-          tf_td  = term-frequency of t in d
-          |d|   = document length
-          avgdl = average document length in the corpus
-          k1, b, δ = BM25L parameters
 
-        addresses the length bias issue described in the paper,
-        where standard BM25 unfairly penalizes longer documents
-        by adding the delta parameter to c_td, it ensures that longer documents aren't unduly penalized.
+        Note: the leading ``tf_td`` factor is the rank_bm25 form. The canonical
+        Lv & Zhai (2011) BM25L (also implemented by `bm25s`) drops this factor;
+        see :class:`BM25LCanonicalTransformer`.
         """  # noqa
         if copy:
             X = X.copy()
@@ -201,6 +205,52 @@ class BM25LTransformer(BM25TransformerBase):
         # Calculate c_td
         ctd: ndarray = X.data / (1 - self.b + self.b * rep / self.avgdl)
         data: ndarray = X.data * (self.k1 + 1) * (ctd + self.delta) / (self.k1 + ctd + self.delta)
+        X = sp.csr_matrix((data, X.indices, X.indptr), shape=X.shape)
+        if self.use_idf:
+            X = X @ self._idf_diag
+        return X
+
+
+class BM25LCanonicalTransformer(BM25TransformerBase):
+    """
+    Canonical BM25L from Lv & Zhai (2011), as reviewed by Kamphuis et al.
+    (ECIR 2020) and implemented by `bm25s`.
+
+    Differs from :class:`BM25LTransformer` (rank_bm25-compatible) by dropping
+    the extra ``tf_td`` multiplier. Like the original paper, the formula is
+    applied for any (doc, term) pair: documents that do not contain a query
+    term still contribute a constant baseline ``idf * (k1+1)*δ/(k1+δ)``. That
+    baseline is sparse-incompatible, so :meth:`transform` only emits the
+    ``tf > 0`` component; full retrieval scoring (including the absent-term
+    baseline) is provided by ``BM25Vectorizer.score`` / ``rank``.
+    """  # noqa
+
+    @override
+    def _calc_idf(self, df: ndarray, n_samples: int) -> ndarray:
+        """Same IDF as BM25L: ln((N+1)/(n_t+0.5))."""
+        idf: ndarray = np.log((n_samples + 1) / (df + 0.5))
+        return np.maximum(idf, self.epsilon * float(np.mean(idf)))
+
+    @override
+    def transform(self, X: csr_matrix, copy: bool = True) -> csr_matrix:
+        """
+        Canonical BM25L score for term t with tf_td > 0 in document d:
+
+                                       (k1 + 1) · (c_td + δ)
+        BM25L(t, d) = idf(t) · ----------------------------------
+                                          k1 + c_td + δ
+
+        Documents with ``tf_td = 0`` would, under the canonical formula,
+        receive ``idf · (k1+1)·δ / (k1+δ)``; that constant is omitted here
+        for sparse compatibility. Use ``BM25Vectorizer.score`` to include it.
+        """  # noqa
+        if copy:
+            X = X.copy()
+        nnz_per_doc: ndarray = np.diff(X.indptr)
+        dl: ndarray = X.sum(axis=1).A1
+        rep: ndarray = np.repeat(dl, nnz_per_doc)
+        ctd: ndarray = X.data / (1 - self.b + self.b * rep / self.avgdl)
+        data: ndarray = (self.k1 + 1) * (ctd + self.delta) / (self.k1 + ctd + self.delta)
         X = sp.csr_matrix((data, X.indices, X.indptr), shape=X.shape)
         if self.use_idf:
             X = X @ self._idf_diag
@@ -721,6 +771,7 @@ class BM25Vectorizer(TfidfVectorizer, SimilarityMixin):
     transformer_dispatch: dict[str, Type[BM25TransformerBase]] = {
         "bm25": BM25Transformer,
         "bm25l": BM25LTransformer,
+        "bm25l_canonical": BM25LCanonicalTransformer,
         "bm25plus": BM25PlusTransformer,
         "bm25adpt": BM25AdptTransformer,
         "bm25t": BM25TTransformer,
@@ -729,7 +780,9 @@ class BM25Vectorizer(TfidfVectorizer, SimilarityMixin):
 
     def __init__(
         self,
-        transformer: Literal["bm25", "bm25l", "bm25plus", "bm25adpt", "bm25t", "tfidf1ap"] = "bm25",
+        transformer: Literal[
+            "bm25", "bm25l", "bm25l_canonical", "bm25plus", "bm25adpt", "bm25t", "tfidf1ap"
+        ] = "bm25",
         k1: float = 1.5,
         b: float = 0.75,
         delta: float = 1.0,
@@ -831,6 +884,8 @@ class BM25Vectorizer(TfidfVectorizer, SimilarityMixin):
         tf = self._get_weighting_transformer(transformer)
         if isinstance(tf, BM25PlusTransformer):
             return self._score_bm25plus(query_counts, document_counts, tf)
+        if isinstance(tf, BM25LCanonicalTransformer):
+            return self._score_bm25l_canonical(query_counts, document_counts, tf)
 
         document_weights = tf.transform(document_counts)
         return (query_counts @ document_weights.T).toarray()
@@ -875,6 +930,33 @@ class BM25Vectorizer(TfidfVectorizer, SimilarityMixin):
         scores = (query_counts @ component.T).toarray()
         return scores + np.asarray(baseline).reshape(-1, 1)
 
+    def _score_bm25l_canonical(
+        self,
+        query_counts: csr_matrix,
+        document_counts: csr_matrix,
+        transformer: "BM25LCanonicalTransformer",
+    ) -> ndarray:
+        if query_counts.shape[1] != document_counts.shape[1]:
+            raise ValueError("query and document matrices must have the same number of features")
+
+        document_weights = transformer.transform(document_counts)
+        scores = (query_counts @ document_weights.T).toarray()
+
+        tfc_absent = (transformer.k1 + 1) * transformer.delta / (transformer.k1 + transformer.delta)
+        if transformer.use_idf:
+            idf = transformer._idf_diag.diagonal()
+            weight = idf * tfc_absent
+        else:
+            weight = np.full(document_counts.shape[1], tfc_absent)
+
+        baseline = np.asarray(query_counts @ weight).reshape(-1, 1)
+
+        has_term = (document_counts > 0).astype(np.float64)
+        weighted_query = query_counts.multiply(weight)
+        correction = (weighted_query @ has_term.T).toarray()
+
+        return scores + baseline - correction
+
     def rank(
         self,
         queries: str | Iterable[str] | sp.spmatrix,
@@ -904,7 +986,8 @@ class BM25Vectorizer(TfidfVectorizer, SimilarityMixin):
             raise ValueError("top_n must be between 1 and the number of documents")
 
         tf = self._get_weighting_transformer(transformer)
-        document_weights = None if isinstance(tf, BM25PlusTransformer) else tf.transform(document_counts)
+        needs_special_score = isinstance(tf, (BM25PlusTransformer, BM25LCanonicalTransformer))
+        document_weights = None if needs_special_score else tf.transform(document_counts)
         ranked_batches = []
         score_batches = []
 
@@ -913,6 +996,8 @@ class BM25Vectorizer(TfidfVectorizer, SimilarityMixin):
             query_batch = query_counts[start:end]
             if isinstance(tf, BM25PlusTransformer):
                 score_batch = self._score_bm25plus(query_batch, document_counts, tf)
+            elif isinstance(tf, BM25LCanonicalTransformer):
+                score_batch = self._score_bm25l_canonical(query_batch, document_counts, tf)
             else:
                 score_batch = (query_batch @ document_weights.T).toarray()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "bm25_vectorizer"
 description = "BM25 Vectorizer (Scikit-learn Compatible)"
 readme = "README.md"
-version = "0.0.3"
+version = "0.0.4"
 license = {text = "MIT"}
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -1,11 +1,12 @@
 import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 import numpy as np
 import scipy.sparse as sp
-from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import Normalizer
@@ -185,9 +186,564 @@ class TestBM25VectorizerExtended(unittest.TestCase):
         result_with_idf = vec_with_idf.transform([self.query])
         result_without_idf = vec_without_idf.transform([self.query])
 
+        self.assertTrue(vec_with_idf._tfidf.use_idf)
+        self.assertFalse(vec_without_idf._tfidf.use_idf)
         self.assertFalse(
             np.allclose(result_with_idf.data, result_without_idf.data), "Results should differ with use_idf parameter"
         )
+
+    def test_fit_uses_raw_term_counts(self):
+        corpus = ["a a a", "a b"]
+        vec = BM25Vectorizer(
+            transformer="bm25",
+            k1=1.5,
+            b=0.75,
+            epsilon=0.0,
+            log1p_idf=True,
+            token_pattern=r"(?u)\b\w+\b",
+            stop_words=None,
+        ).fit(corpus)
+
+        features = list(vec.get_feature_names_out())
+        term_idx = features.index("a")
+        X = vec.transform(corpus).toarray()
+
+        n_samples = 2
+        df_a = 2
+        idf_a = np.log1p((n_samples - df_a + 0.5) / (df_a + 0.5))
+        avgdl = 2.5
+        dl = 3
+        tf = 3
+        expected = idf_a * (tf * (1.5 + 1)) / (tf + 1.5 * (1 - 0.75 + 0.75 * dl / avgdl))
+
+        self.assertEqual(vec._tfidf.avgdl, avgdl)
+        self.assertAlmostEqual(X[0, term_idx], expected)
+
+    def test_fit_transform_does_not_use_sklearn_tfidf_weights(self):
+        corpus = ["a a a b", "a b", "b c"]
+        kwargs = {"token_pattern": r"(?u)\b\w+\b", "stop_words": None}
+
+        vec = BM25Vectorizer(
+            transformer="bm25",
+            log1p_idf=True,
+            norm="l2",
+            smooth_idf=True,
+            sublinear_tf=True,
+            **kwargs,
+        )
+        bm25 = vec.fit_transform(corpus)
+
+        counts = CountVectorizer(**kwargs).fit_transform(corpus)
+        tfidf = TfidfVectorizer(**kwargs).fit_transform(corpus)
+
+        self.assertIsInstance(vec, TfidfVectorizer)
+        self.assertTrue(np.array_equal(vec._tfidf.doc_len_, counts.sum(axis=1).A1))
+        self.assertFalse(np.allclose(bm25.toarray(), tfidf.toarray()))
+        self.assertFalse(np.allclose(vec.transform(corpus).toarray(), counts.toarray()))
+
+    def test_reference_rank_bm25_term_weights(self):
+        try:
+            from rank_bm25 import BM25L, BM25Okapi, BM25Plus
+        except ImportError:
+            self.skipTest("rank_bm25 is not installed")
+
+        tokenized = [
+            ["alpha", "alpha", "beta"],
+            ["beta", "gamma"],
+            ["delta", "gamma", "gamma"],
+            ["epsilon", "zeta"],
+        ]
+        corpus = [" ".join(doc) for doc in tokenized]
+        kwargs = {
+            "k1": 1.5,
+            "b": 0.75,
+            "delta": 1.0,
+            "token_pattern": r"(?u)\b\w+\b",
+            "stop_words": None,
+        }
+        cases = [
+            ("bm25", BM25Okapi(tokenized, k1=1.5, b=0.75, epsilon=0.25)),
+            ("bm25l", BM25L(tokenized, k1=1.5, b=0.75, delta=1.0)),
+            ("bm25plus", BM25Plus(tokenized, k1=1.5, b=0.75, delta=1.0)),
+        ]
+
+        for variant, reference in cases:
+            vec = BM25Vectorizer(transformer=variant, **kwargs).fit(corpus)
+            X = vec.transform(corpus).toarray()
+            counts = CountVectorizer(token_pattern=r"(?u)\b\w+\b", stop_words=None).fit_transform(corpus).toarray()
+
+            for term_idx, term in enumerate(vec.get_feature_names_out()):
+                expected = np.array(reference.get_scores([term]))
+                mask = counts[:, term_idx] > 0
+                self.assertTrue(
+                    np.allclose(X[mask, term_idx], expected[mask]),
+                    f"{variant}: term weights for {term} should match rank_bm25",
+                )
+
+    def test_direct_score_matches_rank_bm25_for_core_variants(self):
+        try:
+            from rank_bm25 import BM25L, BM25Okapi, BM25Plus
+        except ImportError:
+            self.skipTest("rank_bm25 is not installed")
+
+        tokenized = [
+            ["alpha", "alpha", "beta"],
+            ["beta", "gamma"],
+            ["delta", "gamma", "gamma"],
+            ["epsilon", "zeta"],
+        ]
+        corpus = [" ".join(doc) for doc in tokenized]
+        queries = [
+            ["alpha", "gamma"],
+            ["epsilon", "missing"],
+            ["beta", "beta", "gamma"],
+        ]
+        kwargs = {
+            "k1": 1.5,
+            "b": 0.75,
+            "delta": 1.0,
+            "token_pattern": r"(?u)\b\w+\b",
+            "stop_words": None,
+        }
+        cases = [
+            ("bm25", BM25Okapi(tokenized, k1=1.5, b=0.75, epsilon=0.25)),
+            ("bm25l", BM25L(tokenized, k1=1.5, b=0.75, delta=1.0)),
+            ("bm25plus", BM25Plus(tokenized, k1=1.5, b=0.75, delta=1.0)),
+        ]
+
+        for variant, reference in cases:
+            vec = BM25Vectorizer(transformer=variant, **kwargs).fit(corpus)
+            actual = vec.score([" ".join(query) for query in queries])
+            expected = np.vstack([reference.get_scores(query) for query in queries])
+
+            self.assertTrue(np.allclose(actual, expected), f"{variant}: direct scores should match rank_bm25")
+
+    def test_bm25plus_score_includes_absent_query_term_delta(self):
+        corpus = ["alpha beta", "gamma delta"]
+        vec = BM25Vectorizer(
+            transformer="bm25plus",
+            token_pattern=r"(?u)\b\w+\b",
+            stop_words=None,
+            delta=1.0,
+        ).fit(corpus)
+
+        scores = vec.score(["alpha"])
+        transformed_scores = vec.transform(["alpha"]).dot(vec.transform(corpus).T).toarray()
+
+        self.assertGreater(scores[0, 1], 0.0)
+        self.assertEqual(transformed_scores[0, 1], 0.0)
+
+    def test_rank_uses_direct_scores(self):
+        corpus = ["alpha beta", "gamma delta", "alpha alpha gamma"]
+        vec = BM25Vectorizer(
+            transformer="bm25",
+            token_pattern=r"(?u)\b\w+\b",
+            stop_words=None,
+            log1p_idf=True,
+        ).fit(corpus)
+
+        ranked, scores = vec.rank(["alpha", "delta"], top_n=2, return_scores=True)
+        direct_scores = vec.score(["alpha", "delta"])
+
+        self.assertEqual(ranked.shape, (2, 2))
+        self.assertTrue(np.allclose(scores, np.take_along_axis(direct_scores, ranked, axis=1)))
+        self.assertEqual(ranked[0, 0], 2)
+        self.assertEqual(ranked[1, 0], 1)
+
+    def test_rank_batches_match_full_score_sorting(self):
+        corpus = [
+            "alpha beta",
+            "alpha alpha gamma",
+            "delta epsilon",
+            "gamma delta",
+            "zeta eta theta",
+        ]
+        queries = ["alpha", "delta gamma", "theta"]
+
+        for variant in ["bm25", "bm25plus"]:
+            vec = BM25Vectorizer(
+                transformer=variant,
+                token_pattern=r"(?u)\b\w+\b",
+                stop_words=None,
+                log1p_idf=True,
+            ).fit(corpus)
+            scores = vec.score(queries)
+            expected_ranked = np.argsort(scores, axis=1)[:, ::-1][:, :3]
+            expected_scores = np.take_along_axis(scores, expected_ranked, axis=1)
+
+            ranked, sorted_scores = vec.rank(queries, top_n=3, return_scores=True, batch_size=1)
+
+            self.assertTrue(np.array_equal(ranked, expected_ranked), variant)
+            self.assertTrue(np.allclose(sorted_scores, expected_scores), variant)
+
+    def test_similarity_alternative_term_specific_transformers_use_fitted_counts(self):
+        corpus = ["alpha alpha beta", "beta gamma", "gamma gamma delta"]
+        vec = BM25Vectorizer(
+            transformer="bm25",
+            token_pattern=r"(?u)\b\w+\b",
+            stop_words=None,
+        ).fit(corpus)
+
+        for transformer in ["bm25t", "bm25adpt"]:
+            sim = vec.similarity(corpus[0], corpus[1], transformer=transformer)
+            self.assertTrue(np.isfinite(sim))
+
+    def test_bm25adpt_against_independent_oracle(self):
+        corpus = [
+            "alpha alpha alpha beta",
+            "alpha beta beta",
+            "beta gamma gamma gamma",
+            "delta gamma",
+        ]
+        k1 = 1.5
+        b = 0.75
+        token_kwargs = {"token_pattern": r"(?u)\b\w+\b", "stop_words": None}
+        vec = BM25Vectorizer(transformer="bm25adpt", k1=k1, b=b, **token_kwargs).fit(corpus)
+        X = CountVectorizer(**token_kwargs).fit_transform(corpus).tocsr()
+        actual = vec.transform(corpus).toarray()
+
+        df = np.bincount(X.indices, minlength=X.shape[1])
+        dl = X.sum(axis=1).A1
+        avgdl = dl.mean()
+        n_samples, n_terms = X.shape
+
+        def df_r(r):
+            if r == 0:
+                return np.full(n_terms, n_samples)
+            if r == 1:
+                return df
+            out = np.zeros(n_terms, dtype=np.int32)
+            for doc_idx in range(n_samples):
+                start, end = X.indptr[doc_idx], X.indptr[doc_idx + 1]
+                norm = 1 - b + b * dl[doc_idx] / avgdl
+                for pos in range(start, end):
+                    c_td = X.data[pos] / norm
+                    if c_td >= r - 0.5:
+                        out[X.indices[pos]] += 1
+            return out
+
+        max_r = 5
+        df_values = [df_r(r) for r in range(max_r + 2)]
+        g_values = []
+        for r in range(max_r):
+            g_values.append(
+                np.log2((df_values[r + 2] + 0.5) / (df_values[r + 1] + 1))
+                - np.log2((df_values[r + 1] + 0.5) / (n_samples + 1))
+            )
+        g_1 = g_values[0]
+        g_normalized = [np.divide(g, g_1, out=np.zeros_like(g), where=g_1 != 0) for g in g_values]
+
+        k1_terms = np.full(n_terms, k1)
+        for term_idx in range(n_terms):
+            best_k1 = k1
+            min_error = float("inf")
+            for candidate in np.linspace(0.1, 5.0, 50):
+                error = 0.0
+                for r in range(1, max_r + 1):
+                    bm25_component = (candidate + 1) * r / (candidate + r)
+                    error += (g_normalized[r - 1][term_idx] - bm25_component) ** 2
+                if error < min_error:
+                    min_error = error
+                    best_k1 = candidate
+            k1_terms[term_idx] = best_k1
+
+        expected = np.zeros_like(actual)
+        for doc_idx in range(n_samples):
+            start, end = X.indptr[doc_idx], X.indptr[doc_idx + 1]
+            norm = 1 - b + b * dl[doc_idx] / avgdl
+            for pos in range(start, end):
+                term_idx = X.indices[pos]
+                tf = X.data[pos]
+                expected[doc_idx, term_idx] = g_1[term_idx] * tf * (k1_terms[term_idx] + 1) / (
+                    k1_terms[term_idx] * norm + tf
+                )
+
+        self.assertTrue(np.allclose(actual, expected))
+
+    def test_bm25t_against_independent_oracle(self):
+        corpus = [
+            "alpha alpha alpha beta",
+            "alpha beta beta",
+            "beta gamma gamma gamma",
+            "delta gamma",
+        ]
+        k1 = 1.5
+        b = 0.75
+        token_kwargs = {"token_pattern": r"(?u)\b\w+\b", "stop_words": None}
+        vec = BM25Vectorizer(transformer="bm25t", k1=k1, b=b, **token_kwargs).fit(corpus)
+        X = CountVectorizer(**token_kwargs).fit_transform(corpus).tocsr()
+        actual = vec.transform(corpus).toarray()
+
+        df = np.bincount(X.indices, minlength=X.shape[1])
+        dl = X.sum(axis=1).A1
+        avgdl = dl.mean()
+        n_samples, n_terms = X.shape
+
+        idf = np.log((n_samples + 1) / (df + 0.5))
+        idf = np.maximum(idf, 0.25 * float(np.mean(idf)))
+
+        def g_k1(value):
+            if abs(value - 1.0) < 1e-10:
+                return 1.0
+            return (value / (value - 1.0)) * np.log(value)
+
+        def g_k1_derivative(value):
+            if abs(value - 1.0) < 1e-10:
+                return 0.5
+            return np.log(value) / (value - 1) - value * np.log(value) / ((value - 1) ** 2) + 1 / (value - 1)
+
+        k1_terms = np.full(n_terms, k1)
+        for term_idx in range(n_terms):
+            if df[term_idx] == 0:
+                continue
+            log_ctd_sum = 0.0
+            for doc_idx in range(n_samples):
+                start, end = X.indptr[doc_idx], X.indptr[doc_idx + 1]
+                positions = np.where(X.indices[start:end] == term_idx)[0]
+                if len(positions) == 0:
+                    continue
+                tf = X.data[start + positions[0]]
+                norm = 1 - b + b * dl[doc_idx] / avgdl
+                c_td = tf / norm
+                log_ctd_sum += np.log(c_td + 1)
+            target = log_ctd_sum / df[term_idx]
+
+            current = k1
+            for _ in range(20):
+                error = g_k1(current) - target
+                if abs(error) < 1e-6:
+                    break
+                derivative = g_k1_derivative(current)
+                if abs(derivative) <= 1e-10:
+                    break
+                current = max(0.1, current - error / derivative)
+            k1_terms[term_idx] = current
+
+        expected = np.zeros_like(actual)
+        for doc_idx in range(n_samples):
+            start, end = X.indptr[doc_idx], X.indptr[doc_idx + 1]
+            norm = 1 - b + b * dl[doc_idx] / avgdl
+            for pos in range(start, end):
+                term_idx = X.indices[pos]
+                tf = X.data[pos]
+                expected[doc_idx, term_idx] = idf[term_idx] * tf * (k1_terms[term_idx] + 1) / (
+                    tf + k1_terms[term_idx] * norm
+                )
+
+        self.assertTrue(np.allclose(actual, expected))
+
+    def test_ir_retrieval_top1_across_topics(self):
+        corpus = [
+            "python pandas data analysis tutorial",
+            "python machine learning model training",
+            "javascript web browser frontend app",
+            "statistical data analysis regression model",
+            "recipe bread yeast sourdough baking",
+            "football match goal team league",
+        ]
+        queries = {
+            "python data analysis": 0,
+            "frontend browser javascript": 2,
+            "sourdough bread recipe": 4,
+            "football goal match": 5,
+            "regression statistical analysis": 3,
+        }
+
+        for variant in ["bm25", "bm25l", "bm25plus"]:
+            vec = BM25Vectorizer(
+                transformer=variant,
+                token_pattern=r"(?u)\b\w+\b",
+                stop_words=None,
+                log1p_idf=True,
+            ).fit(corpus)
+            document_vectors = vec.transform(corpus)
+
+            for query, expected_top_idx in queries.items():
+                query_vector = vec.transform([query])
+                scores = cosine_similarity(query_vector, document_vectors).ravel()
+                ranked = scores.argsort()[::-1]
+
+                self.assertEqual(ranked[0], expected_top_idx, f"{variant}: wrong top-1 for query {query!r}")
+                self.assertGreater(scores[ranked[0]], 0.0, f"{variant}: top score should be non-zero")
+
+    def test_ir_retrieval_prefers_specific_rare_match(self):
+        corpus = [
+            "python data data tutorial common",
+            "python raretoken exact match",
+            "common common common data",
+            "javascript frontend browser",
+        ]
+        query = "python raretoken"
+
+        for variant in ["bm25", "bm25l", "bm25plus"]:
+            vec = BM25Vectorizer(
+                transformer=variant,
+                token_pattern=r"(?u)\b\w+\b",
+                stop_words=None,
+                log1p_idf=True,
+            ).fit(corpus)
+            scores = cosine_similarity(vec.transform([query]), vec.transform(corpus)).ravel()
+            ranked = scores.argsort()[::-1]
+
+            self.assertEqual(ranked[0], 1, f"{variant}: rare exact match should rank first")
+            self.assertGreater(scores[1], scores[0], f"{variant}: rare term should beat common overlap")
+
+    def test_ir_manual_50_documents_10_queries_and_tfidf_math_comparison(self):
+        corpus = [
+            "python pandas dataframe groupby analysis",
+            "python numpy vector matrix linear algebra",
+            "javascript react frontend browser component",
+            "postgres sql index query optimizer",
+            "machine learning gradient boosting classifier",
+            "neural network transformer attention embeddings",
+            "docker container kubernetes deployment cluster",
+            "linux kernel scheduler process memory",
+            "api authentication oauth jwt token",
+            "cache redis latency throughput performance",
+            "battery charging overheating safety recall",
+            "electric vehicle battery range charging station",
+            "solar panel inverter grid storage",
+            "mortgage interest escrow closing appraisal",
+            "tax deduction invoice accounting audit",
+            "contract clause liability indemnity arbitration",
+            "clinical trial placebo dosage efficacy",
+            "protein enzyme receptor binding assay",
+            "football striker goal penalty league",
+            "basketball rebound assist defense playoff",
+            "sourdough starter yeast flour fermentation",
+            "espresso grinder extraction crema roast",
+            "flight booking luggage airport boarding",
+            "hotel reservation checkout breakfast concierge",
+            "camera aperture shutter iso exposure",
+            "guitar chord fret tuning amplifier",
+            "climate carbon emission warming policy",
+            "ocean coral reef marine biodiversity",
+            "quantum photon entanglement measurement",
+            "telescope galaxy nebula redshift observation",
+            "python python python python tutorial basics",
+            "data data data common common analysis",
+            "battery battery battery charging common",
+            "contract contract clause legal common",
+            "football football goal common common",
+            "recipe bread yeast oven common",
+            "browser javascript css html common",
+            "database sql table join common",
+            "neural neural model training common",
+            "finance stock portfolio risk common",
+            "pandas dataframe merge missing values cleanup",
+            "oauth token refresh session security",
+            "kubernetes pod service ingress deployment",
+            "clinical dosage adverse event safety",
+            "mortgage refinance rate lender credit",
+            "espresso latte milk steaming cafe",
+            "galaxy telescope spectrum dark matter",
+            "coral bleaching ocean temperature",
+            "camera lens focus portrait bokeh",
+            "guitar pedal distortion tone stage",
+        ]
+        queries = [
+            ("pandas dataframe cleanup", 40),
+            ("oauth refresh token", 41),
+            ("battery safety overheating", 10),
+            ("contract indemnity arbitration", 15),
+            ("football penalty striker", 18),
+            ("sourdough yeast fermentation", 20),
+            ("telescope galaxy redshift", 29),
+            ("clinical dosage efficacy", 16),
+            ("kubernetes deployment ingress", 42),
+            ("espresso extraction crema", 21),
+        ]
+        vectorizer_kwargs = {"token_pattern": r"(?u)\b\w+\b", "stop_words": None}
+
+        bm25 = BM25Vectorizer(transformer="bm25", log1p_idf=True, epsilon=0.0, **vectorizer_kwargs).fit(corpus)
+        tfidf = TfidfVectorizer(**vectorizer_kwargs).fit(corpus)
+        bm25_docs = bm25.transform(corpus)
+        tfidf_docs = tfidf.transform(corpus)
+
+        self.assertFalse(np.allclose(bm25_docs.toarray(), tfidf_docs.toarray()))
+
+        for query, expected_top_idx in queries:
+            bm25_query = bm25.transform([query])
+            tfidf_query = tfidf.transform([query])
+            bm25_scores = cosine_similarity(bm25_query, bm25_docs).ravel()
+            tfidf_scores = cosine_similarity(tfidf_query, tfidf_docs).ravel()
+
+            self.assertEqual(bm25_scores.argsort()[::-1][0], expected_top_idx)
+            self.assertEqual(tfidf_scores.argsort()[::-1][0], expected_top_idx)
+            self.assertGreater(bm25_scores[expected_top_idx], 0.0)
+            self.assertGreater(tfidf_scores[expected_top_idx], 0.0)
+            self.assertFalse(np.allclose(bm25_query.toarray(), tfidf_query.toarray()))
+            self.assertFalse(np.allclose(bm25_scores, tfidf_scores))
+
+        term = "battery"
+        bm25_term_idx = list(bm25.get_feature_names_out()).index(term)
+        bm25_matrix = bm25.transform(corpus).toarray()
+        df = np.count_nonzero(CountVectorizer(**vectorizer_kwargs).fit_transform(corpus).toarray()[:, bm25_term_idx])
+        n_samples = len(corpus)
+        idf = np.log1p((n_samples - df + 0.5) / (df + 0.5))
+        avgdl = np.mean([len(doc.split()) for doc in corpus])
+        k1 = 1.5
+        b = 0.75
+
+        def manual_bm25_weight(tf, dl):
+            norm = 1 - b + b * dl / avgdl
+            return idf * (tf * (k1 + 1)) / (tf + k1 * norm)
+
+        doc_once = 10
+        doc_repeated = 32
+        once_expected = manual_bm25_weight(tf=1, dl=len(corpus[doc_once].split()))
+        repeated_expected = manual_bm25_weight(tf=3, dl=len(corpus[doc_repeated].split()))
+
+        self.assertAlmostEqual(bm25_matrix[doc_once, bm25_term_idx], once_expected)
+        self.assertAlmostEqual(bm25_matrix[doc_repeated, bm25_term_idx], repeated_expected)
+
+        tfidf_raw = TfidfVectorizer(norm=None, **vectorizer_kwargs).fit(corpus)
+        tfidf_term_idx = list(tfidf_raw.get_feature_names_out()).index(term)
+        tfidf_matrix = tfidf_raw.transform(corpus).toarray()
+        sklearn_idf = np.log((1 + n_samples) / (1 + df)) + 1
+
+        self.assertAlmostEqual(tfidf_matrix[doc_once, tfidf_term_idx], sklearn_idf)
+        self.assertAlmostEqual(tfidf_matrix[doc_repeated, tfidf_term_idx], 3 * sklearn_idf)
+        self.assertLess(repeated_expected / once_expected, 3.0)
+
+    @unittest.skipUnless(os.getenv("RUN_HF_DATASET_TESTS") == "1", "set RUN_HF_DATASET_TESTS=1 to run")
+    def test_huggingface_ag_news_1000_document_retrieval(self):
+        from datasets import load_dataset
+
+        train = load_dataset("ag_news", split="train[:1000]")
+        queries = load_dataset("ag_news", split="test[:200]")
+        corpus = [row["text"] for row in train]
+        labels = np.array([row["label"] for row in train])
+        query_texts = [row["text"] for row in queries]
+        query_labels = np.array([row["label"] for row in queries])
+        baseline = np.bincount(labels, minlength=4).max() / len(labels)
+
+        scores_by_variant = {}
+        for variant in ["bm25", "bm25l", "bm25plus", "bm25adpt", "bm25t", "tfidf1ap"]:
+            vec = BM25Vectorizer(transformer=variant, stop_words="english", min_df=2, log1p_idf=True)
+            document_vectors = vec.fit_transform(corpus)
+            query_vectors = vec.transform(query_texts)
+            scores = cosine_similarity(query_vectors, document_vectors)
+            ranked = np.argsort(scores, axis=1)[:, ::-1]
+            top1 = labels[ranked[:, 0]] == query_labels
+            top5 = np.array([query_labels[i] in labels[ranked[i, :5]] for i in range(len(query_texts))])
+
+            self.assertEqual(document_vectors.shape[0], 1000)
+            self.assertEqual(query_vectors.shape[0], 200)
+            self.assertTrue(np.isfinite(scores).all(), f"{variant}: scores should be finite")
+            self.assertEqual(np.count_nonzero(np.max(scores, axis=1) > 0), 200)
+            self.assertGreater(top1.mean(), baseline + 0.2, f"{variant}: top-1 should beat label baseline")
+            self.assertGreater(top5.mean(), 0.9, f"{variant}: top-5 should be high on ag_news")
+            scores_by_variant[variant] = scores
+
+        tfidf = TfidfVectorizer(stop_words="english", min_df=2)
+        tfidf_document_vectors = tfidf.fit_transform(corpus)
+        tfidf_query_vectors = tfidf.transform(query_texts)
+        tfidf_scores = cosine_similarity(tfidf_query_vectors, tfidf_document_vectors)
+
+        self.assertFalse(np.allclose(scores_by_variant["bm25"], tfidf_scores))
+        self.assertFalse(np.allclose(scores_by_variant["bm25"], scores_by_variant["bm25l"]))
+        self.assertFalse(np.allclose(scores_by_variant["bm25"], scores_by_variant["bm25plus"]))
 
     def test_delta_parameter(self):
         # Test delta parameter for BM25L and BM25Plus
@@ -348,13 +904,20 @@ class TestBM25VectorizerExtended(unittest.TestCase):
         examples_dir = ROOT_DIR / "examples"
         import subprocess
 
+        expected_output = {
+            "1_retrieve.py": "Rank 1 (Score: 1.0000): quick fox jumping",
+            "2_match.py": "Document 2: Data analytics with pandas",
+            "3_both.py": "1. [doc_6] (Score: 1.0000): Statistical methods for data analysis",
+        }
+
         for example_file in examples_dir.glob("*.py"):
             result = subprocess.run(
-                ["python", str(example_file)],
+                [sys.executable, str(example_file)],
                 capture_output=True,
                 text=True,
             )
             self.assertEqual(result.returncode, 0, f"Example {example_file} failed with error: {result.stderr}")
+            self.assertIn(expected_output[example_file.name], result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -318,6 +318,60 @@ class TestBM25VectorizerExtended(unittest.TestCase):
 
             self.assertTrue(np.allclose(actual, expected), f"{variant}: direct scores should match rank_bm25")
 
+    def test_bm25l_canonical_matches_bm25s_reference(self):
+        try:
+            import bm25s
+        except ImportError:
+            self.skipTest("bm25s is not installed")
+
+        tokenized = [
+            ["alpha", "alpha", "beta"],
+            ["beta", "gamma"],
+            ["delta", "gamma", "gamma"],
+            ["epsilon", "zeta"],
+        ]
+        corpus = [" ".join(doc) for doc in tokenized]
+        queries = [["alpha"], ["beta"], ["alpha", "gamma"], ["epsilon", "missing"]]
+        kwargs = {"token_pattern": r"(?u)\b\w+\b", "stop_words": None}
+
+        for delta in (0.5, 1.0):
+            ref = bm25s.BM25(method="bm25l", k1=1.5, b=0.75, delta=delta)
+            ref.index(tokenized, show_progress=False)
+            vec = BM25Vectorizer(transformer="bm25l_canonical", k1=1.5, b=0.75, delta=delta, **kwargs).fit(corpus)
+            actual = vec.score([" ".join(q) for q in queries])
+            expected = np.vstack([ref.get_scores(q) for q in queries])
+            self.assertTrue(
+                np.allclose(actual, expected, atol=1e-5),
+                f"bm25l_canonical score must match bm25s for delta={delta}",
+            )
+
+    def test_bm25l_canonical_differs_from_rank_bm25_variant(self):
+        corpus = ["alpha alpha beta", "beta gamma", "delta gamma gamma", "epsilon zeta"]
+        kwargs = {"token_pattern": r"(?u)\b\w+\b", "stop_words": None}
+        rank_vec = BM25Vectorizer(transformer="bm25l", **kwargs).fit(corpus)
+        can_vec = BM25Vectorizer(transformer="bm25l_canonical", **kwargs).fit(corpus)
+
+        rank_scores = rank_vec.score(["alpha gamma"])
+        can_scores = can_vec.score(["alpha gamma"])
+
+        self.assertFalse(np.allclose(rank_scores, can_scores))
+        # Canonical assigns positive baseline to documents missing all query terms;
+        # rank_bm25 form does not.
+        self.assertGreater(can_scores[0, 3], 0.0)
+        self.assertEqual(rank_scores[0, 3], 0.0)
+
+    def test_bm25l_canonical_transform_drops_extra_tf_factor(self):
+        corpus = ["alpha alpha alpha alpha beta"]
+        kwargs = {"token_pattern": r"(?u)\b\w+\b", "stop_words": None}
+        rank_vec = BM25Vectorizer(transformer="bm25l", **kwargs).fit(corpus)
+        can_vec = BM25Vectorizer(transformer="bm25l_canonical", **kwargs).fit(corpus)
+        feats = list(can_vec.get_feature_names_out())
+        ti = feats.index("alpha")
+        rank_w = rank_vec.transform(corpus).toarray()[0, ti]
+        can_w = can_vec.transform(corpus).toarray()[0, ti]
+        # rank_bm25 form has extra tf=4 multiplier vs canonical
+        self.assertAlmostEqual(rank_w / can_w, 4.0, places=4)
+
     def test_bm25plus_score_includes_absent_query_term_delta(self):
         corpus = ["alpha beta", "gamma delta"]
         vec = BM25Vectorizer(
@@ -719,7 +773,7 @@ class TestBM25VectorizerExtended(unittest.TestCase):
         baseline = np.bincount(labels, minlength=4).max() / len(labels)
 
         scores_by_variant = {}
-        for variant in ["bm25", "bm25l", "bm25plus", "bm25adpt", "bm25t", "tfidf1ap"]:
+        for variant in ["bm25", "bm25l", "bm25l_canonical", "bm25plus", "bm25adpt", "bm25t", "tfidf1ap"]:
             vec = BM25Vectorizer(transformer=variant, stop_words="english", min_df=2, log1p_idf=True)
             document_vectors = vec.fit_transform(corpus)
             query_vectors = vec.transform(query_texts)


### PR DESCRIPTION
### Added
- `bm25l_canonical`: canonical BM25L from Lv & Zhai (2011) / Kamphuis et al. (2020).
  `score()` and `rank()` include the constant absent-term baseline
  `idf · (k₁+1)·δ / (k₁+δ)`. Numerically matches `bm25s` `method="bm25l"`.

### Changed
- Existing `bm25l` is documented as the `rank_bm25`-compatible form (carries an extra
  `tf_td` multiplier outside the normalised-tf factor). No behavior change.
- README expanded with formulas for both variants and references to the original paper
  and the Kamphuis 2020 reproducibility study.

### Tests
- 3 new unit tests (`bm25s` parity, divergence from rank_bm25, transform-level ratio).
- HF `ag_news` retrieval test extended to cover `bm25l_canonical`.